### PR TITLE
f5abfd8 でのマージミス修正

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -66,7 +66,13 @@ $('#pickup article').flatHeights();
                         <p>2016年9月17日 文化祭がありました。その様子を掲載します。</p>
                     </article>
                 </a>
-
+                <a href="game1_2016.html">
+                    <article>
+                        <time><span>2016</span>09.13</time>
+                        <h2>2016年度ゲーム紹介その1</h2>
+                        <p>2016年度配布するゲームの紹介第一弾です</p>
+                    </article>
+                </a>
                 <a href="kaijofes2016.html">
                     <article>
                         <time><span>2016</span>09.12</time>


### PR DESCRIPTION
f5abfd8 で消えてしまっていた、「2016年度ゲーム紹介その1」へのリンクを復活
