### PR TITLE
CODE FESTIVAL 2016関係の大会成績追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@ $('#pickup article').flatHeights();
                     <article>
                         <time><span>2016</span>11.27</time>
                         <h2>競技プログラミング大会成績</h2>
-                        <p>11/27のAtCoderで行われた大会の参加成績を公表しました。</p>
+                        <p>11/27にAtCoderで行われた大会の参加成績を公表しました。</p>
                     </article>
                 </a>
                 <!-- ↑↑更新履歴ここまで↑↑ -->

--- a/index.html
+++ b/index.html
@@ -70,9 +70,9 @@ $('#pickup article').flatHeights();
                 <!-- ↓↓更新履歴ここから↓↓ -->
                 <a href="performance/index.html">
                     <article>
-                        <time><span>2016</span>11.26</time>
+                        <time><span>2016</span>11.27</time>
                         <h2>競技プログラミング大会成績</h2>
-                        <p>11/26のAtCoderで行われた大会の参加成績を公表しました。</p>
+                        <p>11/27のAtCoderで行われた大会の参加成績を公表しました。</p>
                     </article>
                 </a>
                 <!-- ↑↑更新履歴ここまで↑↑ -->

--- a/performance/index.html
+++ b/performance/index.html
@@ -75,6 +75,7 @@ $('#pickup article').flatHeights();
                 -->
                 <table class="table_a">
                     <tr><th class="h1">日付</th><th class="h2">大会・コンテスト名</th><th class="h3">成績</th></tr>
+                    <tr><td>2016/11/27</td><td>CODE FESTIVAL 2016 Elimination Tournament Round 2 (Parallel)</td><td>200点</td></tr>
                     <tr><td>2016/11/26</td><td>CODE FESTIVAL 2016 Final (Parallel)</td><td>2200点、400点、100点</td></tr>
                     <tr><td>2016/11/12</td><td>AtCoder Grand Contest 007</td><td>200点、200点、1200点</td></tr>
                     <tr><td>2016/11/06</td><td>AtCoder Regular Contest 063</td><td>700点</td></tr>

--- a/performance/index.html
+++ b/performance/index.html
@@ -75,6 +75,7 @@ $('#pickup article').flatHeights();
                 -->
                 <table class="table_a">
                     <tr><th class="h1">日付</th><th class="h2">大会・コンテスト名</th><th class="h3">成績</th></tr>
+                    <tr><td>2016/11/27</td><td>CODE FESTIVAL 2016 Relay (Parallel)</td><td>200点</td></tr>
                     <tr><td>2016/11/27</td><td>CODE FESTIVAL 2016 Elimination Tournament Round 2 (Parallel)</td><td>200点</td></tr>
                     <tr><td>2016/11/26</td><td>CODE FESTIVAL 2016 Final (Parallel)</td><td>2200点、400点、100点</td></tr>
                     <tr><td>2016/11/12</td><td>AtCoder Grand Contest 007</td><td>200点、200点、1200点</td></tr>


### PR DESCRIPTION
「CODE FESTIVAL 2016 Elimination Tournament Round 2 (Parallel)」と
「CODE FESTIVAL 2016 Relay (Parallel)」の成績を追加します。
前者の200点はBwambocos、後者の200点はyusuke_kiraです（AtCoderID）。
何か間違いがあったら指摘してください。